### PR TITLE
=fix shapefile format export function

### DIFF
--- a/c/photogrammetry/DemFeatures.cpp
+++ b/c/photogrammetry/DemFeatures.cpp
@@ -321,6 +321,7 @@ int DemFeatures::exportShpFeatures(char *filename) {
       createShapefile(getFeatureClass(i), &oSRS, poDS);
     }
   }
+  GDALClose(poDS);
   return 1;
 }
 


### PR DESCRIPTION
Correção de bug reportado por alunos. Em certos casos a exportação de feições para o formato shapefile falhava ao finalizar a gravação dos arquivos.