### PR TITLE
Added Appstream metainfo XML and mime-info format XML.

### DIFF
--- a/data/br.uerj.eng.efoto.metainfo.xml
+++ b/data/br.uerj.eng.efoto.metainfo.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component>
+  <id>br.uerj.eng.efoto</id>
+  <metadata_license>MIT</metadata_license>
+  <name>e-foto</name>
+  <summary>Educational Digital Photogrammetry Workstation</summary>
+  <description>
+    <p>Digital photogrammetric workstation equipped with
+    photogrammetric functionalities for creating topographic
+    tridimensional using aerial photogrammetric images captured by
+    both analog cameras and digital sensors.</p>
+  </description>
+  <mimetypes>
+    <mimetype>application/vnd.e-foto</mimetype>
+  </mimetypes>
+</component>

--- a/data/e-foto-mimeinfo.xml
+++ b/data/e-foto-mimeinfo.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+   <mime-type type="application/vnd.e-foto">
+     <sub-class-of type="application/xml"/>
+     <comment>e-foto project file</comment>
+     <glob pattern="*.epp"/>
+     <magic priority="90">
+       <match value="efotoPhotogrammetricProject" type="string" offset="80:220"/>
+     </magic>
+   </mime-type>
+</mime-info>

--- a/e-foto.pro
+++ b/e-foto.pro
@@ -318,8 +318,12 @@ unix {
     desk.files += efoto.desktop
     icon.path = /usr/share/applications/pixmaps
     icon.files += efoto-icon.png
+    mime.path = /usr/share/mime/packages
+    mime.files += data/e-foto-mimeinfo.xml
+    meta.path = /usr/share/metainfo
+    meta.files += data/br.uerj.eng.efoto.metainfo.xml
 
-    INSTALLS += target desk icon
+    INSTALLS += target desk icon mime meta
     #INCLUDEPATH += /usr/include/  Commented to avoid the fatal error during compilation on Ubuntu 18.04 with g++7, as answered by n.m on stackoverflow:
     #DEPENDPATH += /usr/include/   https://stackoverflow.com/questions/51350998/7515-fatal-error-stdlib-h-no-such-file-or-directory-include-next-stdlib-h/51351206
 


### PR DESCRIPTION
This uses the MIME type "application/vnd.e-foto" proposed in #10.

The installation rule do not work for the mime-info file.  Not sure why.