### PR TITLE
Avoid redefining MIN() and MAX() macros.

### DIFF
--- a/c/infrastructure/Matrix.h
+++ b/c/infrastructure/Matrix.h
@@ -21,8 +21,12 @@
 #include "CommonDef.h"
 #include "RectSupport.h"
 
+#ifndef MAX
 #define MAX(X,Y) (((X)>(Y))?(X):(Y))
+#endif /* MAX */
+#ifndef MIN
 #define MIN(X,Y) (((X)<(Y))?(X):(Y))
+#endif /* MIN */
 
 namespace br {
 namespace uerj {


### PR DESCRIPTION
This get rid of compiler warnings like this:

In file included from c/photogrammetry/DemFeatures.h:31,
                 from c/control/DEMManager.cpp:26:
c/infrastructure/Matrix.h:24: warning: "MAX" redefined
   24 | #define MAX(X,Y) (((X)>(Y))?(X):(Y))
      |
In file included from /usr/include/gdal/cpl_error.h:34,
                 from /usr/include/gdal/cpl_string.h:35,
                 from /usr/include/gdal/ogr_spatialref.h:35,
                 from c/photogrammetry/DemFeatures.h:23:
/usr/include/gdal/cpl_port.h:392: note: this is the location of the previous definition
  392 | #define MAX(a, b) (((a) > (b)) ? (a) : (b))
      |
c/infrastructure/Matrix.h:25: warning: "MIN" redefined
   25 | #define MIN(X,Y) (((X)<(Y))?(X):(Y))
      |
/usr/include/gdal/cpl_port.h:390: note: this is the location of the previous definition
  390 | #define MIN(a, b) (((a) < (b)) ? (a) : (b))
      |