### PR TITLE
Use correct delete call and initialize variables in DemGrid.cpp.

### DIFF
--- a/c/photogrammetry/DemGrid.cpp
+++ b/c/photogrammetry/DemGrid.cpp
@@ -874,7 +874,7 @@ void DemGrid::saveDemEfoto(char * filename)
 
     fclose(fp);
 
-    delete data;
+    delete[] data;
 }
 
 void DemGrid::loadDemEfoto(char * filename)
@@ -1356,7 +1356,7 @@ std::string DemGrid::calculateDemQuality(MatchingPointsList mpl)
 
     bool flag=true;
     int pts_used = mpl.size();
-    double Zmean, Zstd;
+    double Zmean = 0.0, Zstd = 0.0;
 
     while (flag && pts_used > 2)
     {


### PR DESCRIPTION
This get rid of these compiler warnings:

c/photogrammetry/DemGrid.cpp: In member function ‘void br::uerj::eng::efoto::DemGrid::saveDemEf oto(char*)’:
c/photogrammetry/DemGrid.cpp:877:12: warning: ‘void operator delete(void*, std::size_t)’ called on pointer returned from a mismatched allocation function [-Wmismatched-new-delete]
  877 |     delete data;
      |            ^~~~
c/photogrammetry/DemGrid.cpp:862:40: note: returned from ‘void* operator new [](std::size_t)’
  862 |     double *data = new double[file_size];
      |                                        ^
In file included from /usr/include/c++/12/istream:39,
                 from /usr/include/c++/12/sstream:38,
                 from c/photogrammetry/DemGrid.cpp:22:
In member function ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(double) [with _CharT = char; _Traits = std::char_traits<char>]’,
    inlined from ‘std::string br::uerj::eng::efoto::DemGrid::calculateDemQuality(br::uerj::eng::efoto::MatchingPointsList)’ at c/photogrammetry/DemGrid.cpp:1414:46:
/usr/include/c++/12/ostream:221:25: warning: ‘Zstd’ may be used uninitialized [-Wmaybe-uninitialized]
  221 |       { return _M_insert(__f); }
      |                ~~~~~~~~~^~~~~
c/photogrammetry/DemGrid.cpp: In member function ‘std::string br::uerj::eng::efoto::DemGrid::calculateDemQuality(br::uerj::eng::efoto::MatchingPointsList)’:
c/photogrammetry/DemGrid.cpp:1359:19: note: ‘Zstd’ was declared here
 1359 |     double Zmean, Zstd;
      |                   ^~~~
In member function ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(double) [with _CharT = char; _Traits = std::char_traits<char>]’,
    inlined from ‘std::string br::uerj::eng::efoto::DemGrid::calculateDemQuality(br::uerj::eng::efoto::MatchingPointsList)’ at c/photogrammetry/DemGrid.cpp:1413:35:
/usr/include/c++/12/ostream:221:25: warning: ‘Zmean’ may be used uninitialized [-Wmaybe-uninitialized]
  221 |       { return _M_insert(__f); }
      |                ~~~~~~~~~^~~~~
c/photogrammetry/DemGrid.cpp: In member function ‘std::string br::uerj::eng::efoto::DemGrid::calculateDemQuality(br::uerj::eng::efoto::MatchingPointsList)’:
c/photogrammetry/DemGrid.cpp:1359:12: note: ‘Zmean’ was declared here
 1359 |     double Zmean, Zstd;
      |            ^~~~~