### PR TITLE
Dropped storing unused QMessageBox::information() return in variable.

### DIFF
--- a/qt/interface/PTUserInterface_Qt.cpp
+++ b/qt/interface/PTUserInterface_Qt.cpp
@@ -544,7 +544,7 @@ bool PTUserInterface_Qt::calculatePT()
 {
     auto selectedImages = selectionImagesView->getSelectedItens();
     if (selectedImages.size() == 0) {
-        int answer = QMessageBox::information(this,tr("PhotoTriangulation inform"),tr("At least one image must be selected"));
+        (void)QMessageBox::information(this,tr("PhotoTriangulation inform"),tr("At least one image must be selected"));
 
         return false;
     }


### PR DESCRIPTION
This get rid of compiler warning:

qt/interface/PTUserInterface_Qt.cpp: In member function ‘bool br::uerj::eng::efoto::PTUserInterface_Qt::calculatePT()’: qt/interface/PTUserInterface_Qt.cpp:547:13: warning: unused variable ‘answer’ [-Wunused-variable]
  547 |         int answer = QMessageBox::information(this,tr("PhotoTriangulation inform"),tr("At least one image must be selected"));
      |             ^~~~~~