### PR TITLE
Add forgotten MIME type to XDG desktop entry.

### DIFF
--- a/data/br.uerj.eng.efoto.desktop
+++ b/data/br.uerj.eng.efoto.desktop
@@ -8,3 +8,4 @@ Terminal=false
 Type=Application
 StartupNotify=true
 Categories=Education;
+MimeType=application/vnd.e-foto;


### PR DESCRIPTION
This add the MIME type (application/vnd.e-foto) used by the other files using the MIME type, ie data/br.uerj.eng.efoto.metainfo.xml and data/e-foto-mimeinfo.xml.

Related to issue #10.