### PR TITLE
Added space between version number and trailing ().

### DIFF
--- a/qt/infrastructure/AboutForm.cpp
+++ b/qt/infrastructure/AboutForm.cpp
@@ -33,7 +33,7 @@ AboutForm::AboutForm()
 	QString software_name = "e-foto";
 	QString descript_name = tr("A free GNU/GPL educational<br /> digital photogrammetric workstation<br />");
 	QString date_ver_name = tr("Version ");
-	QString size_ver_name = tr("(64 bits, beta)");
+	QString size_ver_name = tr(" (64 bits, beta)");
 	date_ver_name += ver + size_ver_name;
 
 	tag = message.elementByTagAtt("span", "id", "software_name");

--- a/qt/interface/ProjectUserInterface_Qt.cpp
+++ b/qt/interface/ProjectUserInterface_Qt.cpp
@@ -53,7 +53,7 @@ ProjectUserInterface_Qt::ProjectUserInterface_Qt(ProjectManager* manager, QWidge
 
 	// Montar mensagem
 	QString date_ver_name = tr("Version ");
-	QString size_ver_name = tr("(64 bits, beta);");
+	QString size_ver_name = tr(" (64 bits, beta);");
 	QString msg = date_ver_name + ver + size_ver_name;
 
 	version_info->setText(msg);


### PR DESCRIPTION
The about page and project UI look better with a space after the version number.  This is a minor visual improvement.